### PR TITLE
Add requiresMainQueueSetup

### DIFF
--- a/ios/RNShakeEvent.m
+++ b/ios/RNShakeEvent.m
@@ -86,6 +86,9 @@ RCT_EXPORT_MODULE();
                                                 body:nil];
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
 @end
 
 #endif


### PR DESCRIPTION
Fix warning: Module RNShakeEvent requires main queue setup since it overrides 'init' but doesn't implement 'requiresMainQueueSetup'. In a future release React native will default to initializing all native modules on a background thread unless explicity opted-out of.